### PR TITLE
GEAR-23/Next-Stage-of-Opportunity

### DIFF
--- a/unpackaged/main/default/layouts/Opportunity-Opportunity %28Marketing%29 Layout.layout-meta.xml
+++ b/unpackaged/main/default/layouts/Opportunity-Opportunity %28Marketing%29 Layout.layout-meta.xml
@@ -23,6 +23,10 @@
                 <behavior>Edit</behavior>
                 <field>CampaignId</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Next_Stage__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -136,8 +140,8 @@
                 <customLink>DeliveryStatus</customLink>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <platformActionList>

--- a/unpackaged/main/default/layouts/Opportunity-Opportunity %28Sales%29 Layout.layout-meta.xml
+++ b/unpackaged/main/default/layouts/Opportunity-Opportunity %28Sales%29 Layout.layout-meta.xml
@@ -35,6 +35,10 @@
                 <behavior>Edit</behavior>
                 <field>CampaignId</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Next_Stage__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -148,8 +152,8 @@
                 <customLink>DeliveryStatus</customLink>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <platformActionList>

--- a/unpackaged/main/default/layouts/Opportunity-Opportunity %28Support%29 Layout.layout-meta.xml
+++ b/unpackaged/main/default/layouts/Opportunity-Opportunity %28Support%29 Layout.layout-meta.xml
@@ -27,6 +27,10 @@
                 <behavior>Edit</behavior>
                 <field>NextStep</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Next_Stage__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -144,8 +148,8 @@
                 <customLink>DeliveryStatus</customLink>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <platformActionList>

--- a/unpackaged/main/default/layouts/Opportunity-Opportunity Layout.layout-meta.xml
+++ b/unpackaged/main/default/layouts/Opportunity-Opportunity Layout.layout-meta.xml
@@ -31,6 +31,10 @@
                 <behavior>Edit</behavior>
                 <field>LeadSource</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Next_Stage__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -69,8 +73,8 @@
         <detailHeading>false</detailHeading>
         <editHeading>true</editHeading>
         <label>Other Information</label>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
     <layoutSections>
@@ -146,8 +150,8 @@
                 <customLink>DeliveryStatus</customLink>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <platformActionList>

--- a/unpackaged/main/default/objects/Opportunity/fields/Next_Stage__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Opportunity/fields/Next_Stage__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Next_Stage__c</fullName>
+    <externalId>false</externalId>
+    <label>Next Stage</label>
+    <length>100</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/unpackaged/main/default/profiles/Admin.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Admin.profile-meta.xml
@@ -2549,6 +2549,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Analytics Cloud Integration User.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Analytics Cloud Integration User.profile-meta.xml
@@ -1819,6 +1819,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Analytics Cloud Security User.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Analytics Cloud Security User.profile-meta.xml
@@ -1819,6 +1819,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/ContractManager.profile-meta.xml
+++ b/unpackaged/main/default/profiles/ContractManager.profile-meta.xml
@@ -2549,6 +2549,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Custom%3A Marketing Profile.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Custom%3A Marketing Profile.profile-meta.xml
@@ -1804,6 +1804,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.Probability</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Custom%3A Sales Profile.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Custom%3A Sales Profile.profile-meta.xml
@@ -1799,6 +1799,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Custom%3A Support Profile.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Custom%3A Support Profile.profile-meta.xml
@@ -1794,6 +1794,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/MarketingProfile.profile-meta.xml
+++ b/unpackaged/main/default/profiles/MarketingProfile.profile-meta.xml
@@ -2549,6 +2549,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Minimum Access - API Only Integrations.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Minimum Access - API Only Integrations.profile-meta.xml
@@ -337,6 +337,11 @@
         <field>Opportunity.CampaignId</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <layoutAssignments>
         <layout>ApiAnomalyEventStore-API Anomaly Event Store Layout</layout>
     </layoutAssignments>

--- a/unpackaged/main/default/profiles/Minimum Access - Salesforce.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Minimum Access - Salesforce.profile-meta.xml
@@ -514,6 +514,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>ReturnOrder.AccountId</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Read Only.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Read Only.profile-meta.xml
@@ -1814,6 +1814,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Salesforce API Only System Integrations.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Salesforce API Only System Integrations.profile-meta.xml
@@ -1814,6 +1814,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/SolutionManager.profile-meta.xml
+++ b/unpackaged/main/default/profiles/SolutionManager.profile-meta.xml
@@ -2549,6 +2549,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Standard.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Standard.profile-meta.xml
@@ -2549,6 +2549,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Opportunity.Next_Stage__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Opportunity.OrderNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
# Pull Request Description

This pull request introduces several changes to the Salesforce metadata, specifically focusing on the Opportunity object and its associated layouts and profiles. Below is a detailed breakdown of the changes made in each file:

---

## 1. **Opportunity Layouts**
### Files Modified:
- `Opportunity-Opportunity (Marketing) Layout.layout-meta.xml`
- `Opportunity-Opportunity (Sales) Layout.layout-meta.xml`
- `Opportunity-Opportunity (Support) Layout.layout-meta.xml`
- `Opportunity-Opportunity Layout.layout-meta.xml`

### Changes:
- Added a new layout item for the field `Next_Stage__c` with behavior set to `Edit` in each of the layouts.

### Impact:
- This addition allows users to edit the `Next Stage` field directly from the Opportunity layouts. Ensure that users are aware of this new field and its purpose in the context of their workflows.

---

## 2. **Opportunity Field Definition**
### File Modified:
- `Next_Stage__c.field-meta.xml`

### Changes:
- A new custom field `Next_Stage__c` has been created with the following properties:
 - **Label:** Next Stage
 - **Type:** Text
 - **Length:** 100
 - **Required:** false
 - **External ID:** false
 - **Track Feed History:** false
 - **Track Trending:** false
 - **Unique:** false

### Impact:
- This new field will allow users to specify the next stage in the Opportunity process. It is important to ensure that this field is included in any relevant reports and that users are trained on how to utilize it effectively.

---

## 3. **Profile Permissions**
### Files Modified:
- `Admin.profile-meta.xml`
- `Analytics Cloud Integration User.profile-meta.xml`
- `Analytics Cloud Security User.profile-meta.xml`
- `ContractManager.profile-meta.xml`
- `Custom: Marketing Profile.profile-meta.xml`
- `Custom: Sales Profile.profile-meta.xml`
- `Custom: Support Profile.profile-meta.xml`
- `MarketingProfile.profile-meta.xml`
- `Minimum Access - API Only Integrations.profile-meta.xml`
- `Minimum Access - Salesforce.profile-meta.xml`
- `Read Only.profile-meta.xml`
- `Salesforce API Only System Integrations.profile-meta.xml`
- `SolutionManager.profile-meta.xml`
- `Standard.profile-meta.xml`

### Changes:
- Added field permissions for `Next_Stage__c` to each profile, allowing:
 - **Editable:** true
 - **Readable:** true

### Impact:
- By granting permissions to the `Next_Stage__c` field across various profiles, users in these roles will be able to view and edit this field. It is crucial to verify that the permissions align with the intended access levels for each user role to maintain data integrity and security.

---

## Summary
This PR introduces the following key updates:
- Addition of the `Next_Stage__c` field to the Opportunity object, enhancing the tracking of Opportunity stages.
- Updates to multiple layouts to include the new field, improving user interaction and data entry.
- Adjustments to profile permissions to ensure appropriate access to the new field.

### Testing Recommendations:
1. Verify that the `Next_Stage__c` field appears correctly in all modified layouts and is editable as expected.
2. Ensure that the field is functioning correctly in the context of Opportunity processes and workflows.
3. Confirm that all profiles have the correct permissions set for the new field and that users can access it as intended.