### PR TITLE
GEAR-24/State-on-Opportunity

### DIFF
--- a/unpackaged/main/default/layouts/Opportunity-Opportunity %28Marketing%29 Layout.layout-meta.xml
+++ b/unpackaged/main/default/layouts/Opportunity-Opportunity %28Marketing%29 Layout.layout-meta.xml
@@ -23,6 +23,10 @@
                 <behavior>Edit</behavior>
                 <field>CampaignId</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>State__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -136,8 +140,8 @@
                 <customLink>DeliveryStatus</customLink>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <platformActionList>

--- a/unpackaged/main/default/layouts/Opportunity-Opportunity %28Sales%29 Layout.layout-meta.xml
+++ b/unpackaged/main/default/layouts/Opportunity-Opportunity %28Sales%29 Layout.layout-meta.xml
@@ -35,6 +35,10 @@
                 <behavior>Edit</behavior>
                 <field>CampaignId</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>State__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -148,8 +152,8 @@
                 <customLink>DeliveryStatus</customLink>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <platformActionList>

--- a/unpackaged/main/default/layouts/Opportunity-Opportunity %28Support%29 Layout.layout-meta.xml
+++ b/unpackaged/main/default/layouts/Opportunity-Opportunity %28Support%29 Layout.layout-meta.xml
@@ -27,6 +27,10 @@
                 <behavior>Edit</behavior>
                 <field>NextStep</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>State__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -144,8 +148,8 @@
                 <customLink>DeliveryStatus</customLink>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <platformActionList>

--- a/unpackaged/main/default/layouts/Opportunity-Opportunity Layout.layout-meta.xml
+++ b/unpackaged/main/default/layouts/Opportunity-Opportunity Layout.layout-meta.xml
@@ -31,6 +31,10 @@
                 <behavior>Edit</behavior>
                 <field>LeadSource</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>State__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -69,8 +73,8 @@
         <detailHeading>false</detailHeading>
         <editHeading>true</editHeading>
         <label>Other Information</label>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
     <layoutSections>
@@ -146,8 +150,8 @@
                 <customLink>DeliveryStatus</customLink>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <platformActionList>

--- a/unpackaged/main/default/objects/Opportunity/fields/State__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Opportunity/fields/State__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>State__c</fullName>
+    <externalId>false</externalId>
+    <label>State</label>
+    <length>100</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
# Pull Request Description

This pull request introduces several changes to the layout metadata for the Opportunity object in Salesforce, as well as the addition of a new custom field. Below is a detailed breakdown of the changes made in each file:

---

## 1. **Opportunity-Opportunity (Marketing) Layout.layout-meta.xml** 
**Changes:** 
- Added a new layout item for the field `State__c` with edit behavior. 
- Adjusted formatting of empty layout columns to use self-closing tags.

**Impact:** 
- The addition of the `State__c` field allows users to edit this field directly from the Opportunity layout in the Marketing context. Ensure that this field is properly populated and utilized in any related processes or reports.

---

## 2. **Opportunity-Opportunity (Sales) Layout.layout-meta.xml** 
**Changes:** 
- Similar to the Marketing layout, a new layout item for the field `State__c` has been added. 
- Formatting adjustments made to empty layout columns.

**Impact:** 
- This change enhances the Sales layout by providing access to the `State__c` field, which may be critical for sales processes. Review any dependencies or automation that may rely on this field.

---

## 3. **Opportunity-Opportunity (Support) Layout.layout-meta.xml** 
**Changes:** 
- Added the `State__c` field with edit behavior to the Support layout. 
- Updated formatting for empty layout columns.

**Impact:** 
- The inclusion of the `State__c` field in the Support layout allows support agents to view and edit this information, which may improve case handling and customer interactions. Validate that this field is integrated into support workflows.

---

## 4. **Opportunity-Opportunity Layout.layout-meta.xml** 
**Changes:** 
- The `State__c` field has been added to the main Opportunity layout. 
- Formatting for empty layout columns has been standardized.

**Impact:** 
- This change ensures that all users interacting with the Opportunity object can access the `State__c` field, which may be important for tracking the state of opportunities across different business processes.

---

## 5. **State__c.field-meta.xml** 
**Changes:** 
- A new custom field `State__c` has been created with the following properties: 
 - Type: Text 
 - Length: 100 
 - Not required 
 - Not an external ID 

**Impact:** 
- The introduction of the `State__c` field provides a new data point for Opportunities, which can be leveraged for reporting, filtering, and business logic. Ensure that this field is included in any relevant data models and that it is properly documented for users.

---

## Summary 
This PR enhances the Opportunity object by adding the `State__c` field across multiple layouts, improving user access and data management. Reviewers should focus on the following: 
1. Ensure that the `State__c` field is correctly integrated into existing processes and reports. 
2. Validate that the layout changes do not disrupt user experience or existing functionality. 
3. Confirm that the new field is documented and communicated to relevant stakeholders.